### PR TITLE
Discord role based priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ Queue.OnJoin(function(source, allow)
     allow("No, you can't join")
 end)
 ```
+### Discord priority start
+### Add following lines in your server.cfg file
+
+```Lua
+set sb:discordBotToken "your bot token here" -- make sure bot has SERVER MEMBERS INTENT, PRESENCE INTENT and MESSAGE CONTENT INTENT enabled
+set sb:discordGuildId "your discord server id"      -- our discord server id
+```
+
+## Add Discord Role as per priority power
+```Lua
+
+Config.PriorityRoles = { --  ["DISCORD_ROLE_ID"] = POWER,
+    ["1186549704318799924"] = 30,  -- Prio 3
+    ["1186549286146678844"] = 20,  -- Prio 2
+    ["1186549574081466408"] = 10,  -- Prio 1
+}
+
+```
+### Discord priority end
+
 
 ## AddPriority
 Call this to add an identifier to the priority list.

--- a/connectqueue/README.md
+++ b/connectqueue/README.md
@@ -1,0 +1,115 @@
+# ConnectQueue
+---
+Easy to use queue system for FiveM with:
+- Simple API
+- Priority System
+- Config
+    - Ability for whitelist only
+    - Require steam
+    - Language options
+
+**Please report any bugs on the release thread [Here](https://forum.fivem.net/t/alpha-connectqueue-a-server-queue-system-fxs/22228) or through [GitHub](https://github.com/Nick78111/ConnectQueue/issues).**
+
+## How to install
+---
+- Drop the folder inside your resources folder.
+- Add `start connectqueue` inside your server.cfg. - *Preferrably at the top*
+- Set convars to your liking.
+- Open `connectqueue/server/sv_queue_config.lua` and edit to your liking.
+- Renaming the resource may cause problems.
+
+## ConVars
+---
+	set sv_debugqueue true # prints debug messages to console
+	set sv_displayqueue true # shows queue count in the server name '[count] server name'
+
+## How to use / Examples
+---
+To use the API add `server_script "@connectqueue/connectqueue.lua"` at the top of the `__resource.lua` file in question.
+I would also suggest adding `dependency "connectqueue"` to it aswell.
+You may now use any of the functions below, anywhere in that resource.
+
+### OnReady
+This is called when the queue functions are ready to be used.
+```Lua
+    Queue.OnReady(function() 
+        print("HI")
+    end)
+```
+All of the functions below must be called **AFTER** the queue is ready.
+
+### OnJoin
+This is called when a player tries to join the server.
+Calling `allow` with no arguments will let them through.
+Calling `allow` with a string will prevent them from joining with the given message.
+`allow` must be called or the player will hang on connecting...
+```Lua
+Queue.OnJoin(function(source, allow)
+    allow("No, you can't join")
+end)
+```
+### Discord priority start
+### Add following lines in your server.cfg file
+
+```Lua
+set sb:discordBotToken "your bot token here" -- make sure bot has SERVER MEMBERS INTENT, PRESENCE INTENT and MESSAGE CONTENT INTENT enabled
+set sb:discordGuildId "your discord server id"      -- our discord server id
+```
+
+## Add Discord Role as per priority power
+```Lua
+
+Config.PriorityRoles = { --  ["DISCORD_ROLE_ID"] = POWER,
+    ["1186549704318799924"] = 30,  -- Prio 3
+    ["1186549286146678844"] = 20,  -- Prio 2
+    ["1186549574081466408"] = 10,  -- Prio 1
+}
+
+```
+### Discord priority end
+
+
+## AddPriority
+Call this to add an identifier to the priority list.
+The integer is how much power they have over other users with priority.
+This function can take a table of ids or individually.
+```Lua
+-- individual
+Queue.AddPriority("STEAM_0:1:33459672", 100)
+Queue.AddPriority("steam:110000103fd1bb1", 10)
+Queue.AddPriority("ip:127.0.0.1", 25)
+
+-- table
+local prioritize = {
+    ["STEAM_0:1:33459672"] = 100,
+    ["steam:110000103fd1bb1"] = 10,
+    ["ip:127.0.0.1"] = 25,
+}
+Queue.AddPriority(prioritize)
+```
+
+## RemovePriority
+Removes priority from a user.
+```Lua
+Queue.RemovePriority("STEAM_0:1:33459672")
+```
+
+## IsReady
+Will return whether or not the queue's exports are ready to be called.
+```Lua
+print(Queue.IsReady())
+```
+
+## Other Queue Functions
+You can call every queue function within sh_queue.lua.
+```Lua
+local ids = Queue.Exports:GetIds(src)
+
+-- sets the player to position 1 in queue
+Queue.Exports:SetPos(ids, 1)
+-- returns whether or not the player has any priority
+Queue.Exports:IsPriority(ids)
+--- returns size of queue
+Queue.Exports:GetSize()
+-- plus many more...
+```

--- a/connectqueue/discordapi.lua
+++ b/connectqueue/discordapi.lua
@@ -1,0 +1,136 @@
+local discordGuildId = GetConvar('sb:discordGuildId', "")
+local FormattedToken = GetConvar('sb:discordBotToken', '')
+
+
+local error_codes_defined = {
+	[200] = 'OK - The request was completed successfully..!',
+	[204] = 'OK - No Content',
+	[400] = "Error - The request was improperly formatted, or the server couldn't understand it..!",
+	[401] =
+	'Error - The Authorization header was missing or invalid..! Your Discord Token is probably wrong or does not have correct permissions attributed to it.',
+	[403] =
+	'Error - The Authorization token you passed did not have permission to the resource..! Your Discord Token is probably wrong or does not have correct permissions attributed to it.',
+	[404] = "Error - The resource at the location specified doesn't exist.",
+	[429] =
+	'Error - Too many requests, you hit the Discord rate limit. https://discord.com/developers/docs/topics/rate-limits',
+	[502] = 'Error - Discord API may be down?...'
+}
+
+function sendDebugMessage(msg)
+	print(msg);
+end
+
+function DiscordRequest(method, endpoint, jsondata, reason)
+	local data = nil
+	PerformHttpRequest("https://discord.com/api/" .. endpoint, function(errorCode, resultData, resultHeaders)
+		data = { data = resultData, code = errorCode, headers = resultHeaders }
+	end, method, #jsondata > 0 and jsondata or "",
+		{ ["Content-Type"] = "application/json", ["Authorization"] = "Bot "..FormattedToken, ['X-Audit-Log-Reason'] = reason })
+
+	while data == nil do
+		Citizen.Wait(0)
+	end
+	return data
+end
+
+Caches = {
+	RoleList = {}
+}
+function ResetCaches()
+	Caches = {
+		RoleList = {},
+	};
+end
+
+function GetGuildRoleList(guild)
+	local guildId = discordGuildId
+	if (Caches.RoleList[guildId] == nil) then
+		local guild = DiscordRequest("GET", "guilds/" .. guildId, {})
+		if guild.code == 200 then
+			local data = json.decode(guild.data)
+			local roles = data.roles;
+			local roleList = {};
+			for i = 1, #roles do
+				roleList[roles[i].name] = roles[i].id;
+			end
+			Caches.RoleList[guildId] = roleList;
+		else
+			sendDebugMessage("An error occured, please check your config and ensure everything is correct. Error: " ..
+			(guild.data or guild.code))
+			Caches.RoleList[guildId] = nil;
+		end
+	end
+	return Caches.RoleList[guildId];
+end
+
+recent_role_cache = {}
+
+function ClearCache(discordId)
+	if (discordId ~= nil) then
+		recent_role_cache[discordId] = {};
+	end
+end
+
+function GetDiscordRoles(user)
+	local discordId = nil
+	local guildId = discordGuildId
+	local roles = nil
+	for _, id in ipairs(GetPlayerIdentifiers(user)) do
+		if string.match(id, "discord:") then
+			discordId = string.gsub(id, "discord:", "")
+			break;
+		end
+	end
+	if discordId then
+		roles = GetUserRolesInGuild(discordId, guildId)
+		return roles
+	else
+		sendDebugMessage("ERROR: Discord was not connected to user's Fivem account...")
+		return false
+	end
+	return false
+end
+
+function GetUserRolesInGuild(user, guild)
+	if not user then
+		sendDebugMessage("ERROR: GetUserRolesInGuild requires discord ID")
+		return false
+	end
+	if not guild then
+		sendDebugMessage("ERROR: GetUserRolesInGuild requires guild ID")
+		return false
+	end
+	if recent_role_cache[user] and recent_role_cache[user][guild] then
+		return recent_role_cache[user][guild]
+	end
+
+	local endpoint = ("guilds/%s/members/%s"):format(guild, user)
+	local member = DiscordRequest("GET", endpoint, {})
+	if member.code == 200 then
+		local data = json.decode(member.data)
+		local roles = data.roles
+		recent_role_cache[user] = recent_role_cache[user] or {}
+		recent_role_cache[user][guild] = roles
+		Citizen.SetTimeout((60 * 1000),
+			function() recent_role_cache[user][guild] = nil end)
+		 
+		return roles
+	else
+		sendDebugMessage("ERROR: Code 200 was not reached... Returning false. [Member Data NOT FOUND] DETAILS: " ..
+		error_codes_defined[member.code])
+		return false
+	end
+end
+
+
+CreateThread(function()
+	local mguild = DiscordRequest("GET", "guilds/" .. discordGuildId, {})
+	if mguild.code == 200 then
+		local data = json.decode(mguild.data)
+		sendDebugMessage("Successful connection to Guild : " .. data.name .. " (" .. data.id .. ")")
+		-- print(json.encode(GetUserRolesInGuild("759846912387579924", "656158231458218034")))
+	else
+		sendDebugMessage("An error occured, please check your config and ensure everything is correct. Error: " ..
+		(mguild.data and json.decode(mguild.data) or mguild.code))
+	end
+end)

--- a/connectqueue/fxmanifest.lua
+++ b/connectqueue/fxmanifest.lua
@@ -1,5 +1,7 @@
 fx_version 'bodacious'
-game 'gta5'
+game 'common'
+
+server_script "discordapi.lua"
 
 server_script "server/sv_queue_config.lua"
 server_script "connectqueue.lua"

--- a/connectqueue/server/sv_queue_config.lua
+++ b/connectqueue/server/sv_queue_config.lua
@@ -4,13 +4,21 @@ Config = {}
 -- a lot of the steamid converting websites are broken rn and give you the wrong steamid. I use https://steamid.xyz/ with no problems.
 -- you can also give priority through the API, read the examples/readme.
 Config.Priority = {
-    ["STEAM_0:1:0000####"] = 1,
-    ["steam:110000######"] = 25,
     ["ip:127.0.0.0"] = 85
 }
 
--- require people to run steam
-Config.RequireSteam = false
+Config.PriorityRoles = { --  ["DISCORD_ROLE_ID"] = POWER,
+    ["880863510475718666"] = 100,  -- Owner
+    ["1186365893576511550"] = 99, -- Bandhilki
+    ["930078697262821417"] = 98, -- Administrator
+    ["899693043471507498"] = 97,  -- Developer
+    ["1186549704318799924"] = 50,  -- Prio 3
+    ["1186549286146678844"] = 40,  -- Prio 2
+    ["1186549574081466408"] = 30,  -- Prio 1
+    ["881112830835834891"] = 5,  -- Staff
+    ["1185812982924591144"] = 4, -- PD
+    ["1185812792301850726"] = 4, -- EMS
+}
 
 -- "whitelist" only server
 Config.PriorityOnly = false
@@ -28,13 +36,17 @@ Config.ConnectTimeOut = 600
 Config.QueueTimeOut = 90
 
 -- will give players temporary priority when they disconnect and when they start loading in
-Config.EnableGrace = false
+Config.EnableGrace = true
 
 -- how much priority power grace time will give
 Config.GracePower = 5
 
 -- how long grace time lasts in seconds
 Config.GraceTime = 480
+
+Config.AntiSpam = false
+Config.AntiSpamTimer = 10
+Config.PleaseWait = "Please wait %d seconds. The connection will start automatically!"
 
 -- on resource start, players can join the queue but will not let them join for __ milliseconds
 -- this will let the queue settle and lets other resources finish initializing
@@ -53,5 +65,6 @@ Config.Language = {
     connectingerr = "\xE2\x9D\x97[Queue] Error: Error adding you to connecting list",
     timedout = "\xE2\x9D\x97[Queue] Error: Timed out?",
     wlonly = "\xE2\x9D\x97[Queue] You must be whitelisted to join this server",
-    steam = "\xE2\x9D\x97 [Queue] Error: Steam must be running"
+    steam = "\xE2\x9D\x97 [Queue] Error: Steam must be running in background",
+    discord = "\xE2\x9D\x97 [Queue] Error: Discord must be running in background"
 }


### PR DESCRIPTION
Now your can manage your queue priority via your discord role. No need to add everytime in config file. just add role to give priority and remove role to remove priority